### PR TITLE
don't include "\n" as ErrorMessage

### DIFF
--- a/lib/repack-result.js
+++ b/lib/repack-result.js
@@ -18,7 +18,7 @@ const getResult = (result, name) => {
 }
 
 module.exports = (result = {}, options) => {
-  if (result.ErrorMessage) return { ErrorMessage: result.ErrorMessage }
+  if (result.ErrorMessage && result.ErrorMessage !== '\n') return { ErrorMessage: result.ErrorMessage }
 
   const names = getNames(result)
   let output = []


### PR DESCRIPTION
I noen metoder sender SIF tilbake "\n" som ErrorMessage og ikke null....